### PR TITLE
Table data export

### DIFF
--- a/src/components/LayoffTable.tsx
+++ b/src/components/LayoffTable.tsx
@@ -1,73 +1,81 @@
-import { useLayoffData } from '../hooks/useLayoffData'
-import { Search } from 'lucide-react' // Import the search icon
+import { getTableData, Header, generateFile } from "@/util/table";
+import { LayoffData, useLayoffData } from "../hooks/useLayoffData";
+import { Download, Search } from "lucide-react"; // Import the search icon
+import { Button } from "./ui/button";
+import Table from "./ui/table";
 
 const LayoffTable = () => {
-  const data = useLayoffData() // Fetch the CSV data using the custom hook
+  const data = useLayoffData(); // Fetch the CSV data using the custom hook
 
   if (data.length === 0) {
-    return <div>Loading...</div> // Loading state while the data is being fetched
+    return <div>Loading...</div>; // Loading state while the data is being fetched
   }
 
-  // Get the headers dynamically from the first row of CSV and add a new "Google Search" column
-  const headers = [...Object.keys(data[0]), "googleSearch"]
-
-  // Utility function to convert strings to camel case
-  const toCamelCase = (str: string) => {
-    return str
-      .replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace('-', '').replace('_', ''))
-      .replace(/^[a-z]/, (group) => group.toUpperCase())
-  }
+  const headers: Header<LayoffData>[] = [
+    {
+      name: "Company",
+      accessor: "company",
+    },
+    {
+      name: "City",
+      accessor: "headquarters",
+    },
+    {
+      name: "Laid Off",
+      accessor: "laidOff",
+    },
+    {
+      name: "Date",
+      accessor: "date",
+    },
+    {
+      name: "Google",
+      accessor: "company",
+      render: (_, row) => (
+        <a
+          href={`https://www.google.com/search?q=${encodeURIComponent(
+            `${row.company} ${row.headquarters} layoffs`
+          )}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 flex items-center justify-center"
+        >
+          <Search className="w-5 h-5" />
+        </a>
+      ),
+      csv: (row) =>
+        `https://www.google.com/search?q=${encodeURIComponent(
+          `${row.company} ${row.headquarters} layoffs`
+        )}`,
+    },
+  ];
 
   return (
-    <div className="table-container my-4">
-      <div
-        className="overflow-x-auto"
-        style={{ maxHeight: "300px", overflowY: "auto" }}
-      >
-        <table className="table-auto w-full text-left border-collapse">
-          <thead className="bg-gray-100 sticky top-0">
-            <tr>
-              {headers.map((header) => (
-                <th key={header} className="border px-4 py-2 font-semibold">
-                  {header === "googleSearch"
-                    ? "Google"
-                    : header === "headquarters" // Rename "headquarters" to "City"
-                    ? "City"
-                    : toCamelCase(header)}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((row, index) => (
-              <tr key={index} className="hover:bg-gray-50">
-                {headers.map((header) => (
-                  <td key={header} className="border px-4 py-2">
-                    {header === "date" && row[header] instanceof Date
-                      ? row[header].toLocaleDateString() // Format Date object as a readable string
-                      : header === "googleSearch" // Generate Google Search link
-                      ? (
-                        <a
-                          href={`https://www.google.com/search?q=${encodeURIComponent(
-                            `${row.company} ${row.headquarters} layoffs`
-                          )}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-600 flex items-center justify-center"
-                        >
-                          <Search className="w-5 h-5" /> {/* Search icon */}
-                        </a>
-                      )
-                      : row[header]}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+    <>
+      <div className="w-full flex justify-end">
+        <Button
+          type="button"
+          onClick={() => generateFile(getTableData(data, headers), "Trendboard", "csv")}
+        >
+          <Download className="w-5 h-5 stroke-primary-foreground" /> CSV
+        </Button>
+        <Button
+          type="button"
+          onClick={() => generateFile(getTableData(data, headers), "Trendboard", "excel")}
+        >
+          <Download className="w-5 h-5 stroke-primary-foreground" /> Excel
+        </Button>
       </div>
-    </div>
+      <div className="table-container my-4">
+        <div
+          className="overflow-x-auto"
+          style={{ maxHeight: "300px", overflowY: "auto" }}
+        >
+          <Table data={data} headers={headers} />
+        </div>
+      </div>
+    </>
   );
-}
+};
 
-export default LayoffTable
+export default LayoffTable;

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,46 @@
+import { Header } from "@/util/table";
+import { JSX } from "react";
+
+interface TableProps<T> {
+  data: T[];
+  headers: Header<T>[];
+}
+
+const Table = <T,>({ data, headers }: TableProps<T>): JSX.Element => {
+  return (
+    <table className="table-auto w-full text-left border-collapse">
+      <thead className="bg-gray-100 sticky top-0">
+        <tr>
+          {headers.map((header) => (
+            <th
+              key={String(header.accessor)}
+              className="border px-4 py-2 font-semibold"
+            >
+              {header.name}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, rowIndex) => (
+          <tr key={rowIndex} className="hover:bg-gray-50">
+            {headers.map((header) => {
+              const cellValue = row[header.accessor];
+              return (
+                <td key={String(header.accessor)} className="border px-4 py-2">
+                  {header.render
+                    ? header.render(cellValue, row)
+                    : header.accessor === "date" && cellValue instanceof Date
+                    ? new Date(cellValue).toLocaleDateString()
+                    : String(cellValue)}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default Table;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,0 +1,5 @@
+declare global {
+  interface Navigator {
+    msSaveBlob?: (blob: Blob, defaultName?: string) => boolean;
+  }
+}

--- a/src/util/table.ts
+++ b/src/util/table.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface Header<T> {
+  name: string;
+  accessor: keyof T;
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  csv?: (row: T) => string;
+}
+
+/**
+ * @desc Get table data as JSON
+ */
+export const getTableData = <T>(data: T[], headers: Header<T>[]) => {
+  return data.map((record) => {
+    const obj: Record<string, string> = {};
+    headers.forEach(({ name, accessor, csv }) => {
+      if (csv) {
+        obj[name] = csv(record);
+      } else {
+        const value = record[accessor];
+        obj[name] = String(value ?? "");
+      }
+    });
+    return obj;
+  });
+};
+
+/**
+ * @desc Generate CSV or Excel from given data
+ */
+export const generateFile = async (
+  rows: Record<string, any>[],
+  filename: string,
+  format: "csv" | "excel"
+) => {
+  if (!rows || rows.length === 0) return;
+
+  const separator = ";";
+  const keys = Object.keys(rows[0]);
+
+  const csvContent = `${keys.join(separator)}\n${rows
+    .map((row) =>
+      keys
+        .map((k) => {
+          let cell = row[k] ?? "";
+
+          cell =
+            cell instanceof Date
+              ? cell.toLocaleString()
+              : cell.toString().replace(/"/g, '""');
+
+          return /("|;|\n)/.test(cell) ? `"${cell}"` : cell;
+        })
+        .join(separator)
+    )
+    .join("\n")}`;
+
+  const type =
+    format === "csv" ? "text/csv;charset=utf-8;" : "application/vnd.ms-excel";
+
+  const blob = new Blob([csvContent], { type: type });
+
+  const link = document.createElement("a");
+  const url = URL.createObjectURL(blob);
+  link.href = url;
+  link.setAttribute("download", filename);
+  link.style.visibility = "hidden";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};


### PR DESCRIPTION
#8 
- Added generic ui table component
  - Should be able to add data and header props and render accordingly
  - AKA be able to add cool new tables easily
- Export capability to table (csv and excel)
- Capability to add manual custom columns (e.g. googleSearch) without potentially ruining integrity of original data

Note: Date data does not match frontend.  Figured this may be ok as it is then explicit to timezone?